### PR TITLE
Fix overwriting of low-level Kafka options with auth options

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,18 @@ auth:
   sasl_mechanism: SCRAM-SHA-512
 ```
 
+If you need to use another variant, use the low-level custom Kafka options `kafka_config:` of `config/kafka_producer.yml`. These options will overwrite the options in the auth section.
+
+Example of SASL_SSL protocol auth via `kafka_config`:
+
+```yaml
+kafka_config:
+  security.protocol: SASL_SSL
+  sasl.username: user
+  sasl.password: pwd
+  ssl.ca.pem: ca_cert
+  sasl.mechanism: SCRAM-SHA-512
+```
 ### `kafka` config section
 
 The `servers` key is required and should be in rdkafka format: without `kafka://` prefix, for example: `srv1:port1,srv2:port2,...`.

--- a/lib/sbmt/kafka_producer/config/producer.rb
+++ b/lib/sbmt/kafka_producer/config/producer.rb
@@ -41,8 +41,8 @@ module Sbmt
         coerce_types auth: coerce_to(Auth)
 
         def to_kafka_options
-          kafka.to_kafka_options
-            .merge(auth.to_kafka_options)
+          auth.to_kafka_options
+            .merge(kafka.to_kafka_options)
         end
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require "pathname"
 ENGINE_ROOT = Pathname.new(File.expand_path("..", __dir__))
 
 require "spec_helper"
+require "logger"
 require "combustion"
 
 begin

--- a/spec/sbmt/kafka_producer/config/producer_spec.rb
+++ b/spec/sbmt/kafka_producer/config/producer_spec.rb
@@ -52,5 +52,39 @@ describe Sbmt::KafkaProducer::Config::Producer, type: :config do
         expect(config.metrics_listener_class).to eq("::Sbmt::KafkaProducer::Instrumentation::YabedaMetricsListener")
       end
     end
+
+    context "when kafka_config options overwrite auth params" do
+      let(:ca_cert) { OpenSSL::PKey::RSA.new(2048).to_s }
+      let(:default_env) do
+        super().merge(
+          "KAFKA_PRODUCER_KAFKA__KAFKA_CONFIG__SECURITY.PROTOCOL" => "SASL_SSL",
+          "KAFKA_PRODUCER_KAFKA__KAFKA_CONFIG__SASL.MECHANISM" => "SCRAM-SHA-512",
+          "KAFKA_PRODUCER_KAFKA__KAFKA_CONFIG__SSL.CA.PEM" => ca_cert
+        )
+      end
+
+      it "properly merges kafka options uses auth params from low-level config" do
+        with_env(default_env) do
+          expect(config.to_kafka_options)
+            .to eq(kafka_config_defaults.merge(
+              "bootstrap.servers": "server1:9092,server2:9092",
+              "security.protocol": "SASL_SSL",
+              "sasl.mechanism": "SCRAM-SHA-512",
+              "ssl.ca.pem": ca_cert,
+              "sasl.password": "password",
+              "sasl.username": "username",
+              # loaded from kafka_producer.yml
+              "message.send.max.retries": 2,
+              "request.required.acks": -1,
+              "request.timeout.ms": 1000,
+              "retry.backoff.ms": 1000,
+              "socket.connection.setup.timeout.ms": 2000,
+              # arbitrary parameters for section kafka_config file kafka_producer.yml
+              "queue.buffering.max.messages": 1,
+              "queue.buffering.max.ms": 10000
+            ))
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
# Context

There was a problem with Kafka authorization due to the fact that the auth options overwritten the low-level kafka_config options. As a result, we could not use SASL_SSL authorization with an SSL certificate. 
I fixed the line where the Kafka configuration was overwritten with the default authorization options. This looks more logical, and makes it possible to configure the connection to Kafka through the low-level config.

# What's inside

- [x] The ability to configure auth for connecting to Kafka through the low-level config
- [x] Fix pipeline `uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger` error in the `spec/rails_helper.rb` on older versions of Rails. Solution: https://github.com/rails/rails/pull/54264#issuecomment-2596149819
Failed job example: https://github.com/lxnewayfarer/sbmt-kafka_producer/actions/runs/12985571892/job/36210696308

# Checklist:

- [x] I have added tests
- [x] I have made corresponding changes to the documentation
